### PR TITLE
chore: add CI, security policy, and issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Questions & Discussion"
+    url: https://github.com/l22-io/orchard-mcp/discussions
+    about: "Ask questions, share configurations, or discuss orchard-mcp"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,25 +2,41 @@
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| 0.3.x   | Yes       |
-| < 0.3   | No        |
+Only the latest release on the `main` branch is supported with security updates.
+
+| Branch | Supported |
+| ------ | --------- |
+| main   | Yes       |
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in orchard-mcp, please report it responsibly:
+Please use [GitHub's private vulnerability reporting](https://github.com/l22-io/orchard-mcp/security/advisories/new) to report security issues. Navigate to the **Security** tab of the repository and select **Report a vulnerability**.
 
-1. **Do not** open a public GitHub issue.
-2. Email **security@l22.io** with a description of the vulnerability.
-3. Include steps to reproduce if possible.
+Do not open a public issue for security vulnerabilities.
 
-We will acknowledge your report within 48 hours and aim to release a fix within 7 days for critical issues.
+## What Qualifies
 
-## Scope
+The following are examples of issues we consider in scope:
 
-orchard-mcp runs locally and accesses macOS data stores (Calendar, Mail, Reminders, filesystem) through native frameworks. It does not communicate with remote services. Security concerns typically involve:
+- **Command injection through the Swift bridge** -- unsanitized input passed to `apple-bridge` subcommands or shell execution (e.g., `osascript` calls in Mail tools).
+- **Unauthorized access to macOS services** -- bypassing or escalating beyond the permissions granted to the MCP server (EventKit, file system, Mail).
+- **Path traversal in file operations** -- accessing files outside of intended directories through crafted tool inputs.
+- **MCP transport or JSON-RPC protocol issues** -- vulnerabilities in the stdio transport layer, malformed message handling, or protocol-level exploits.
+- **Information disclosure** -- leaking sensitive data from macOS services through error messages, logs, or unintended tool output.
 
-- Unintended data exposure through MCP tool responses
-- Path traversal in file operations (all paths are validated against home directory)
-- Command injection in bridge calls (all arguments are passed as arrays, never shell-interpolated)
+## Response Timeline
+
+- **Acknowledgment**: within 72 hours of report submission.
+- **Initial assessment**: within 7 days.
+- **Resolution target**: critical issues within 30 days; lower-severity issues on a best-effort basis.
+
+We will coordinate disclosure with the reporter and credit them in release notes unless they prefer to remain anonymous.
+
+## Out of Scope
+
+The following are not considered vulnerabilities in orchard-mcp:
+
+- **macOS permission prompts and entitlements** -- access control for Calendar, Reminders, Mail, and file system is managed by macOS. Issues with Apple's permission model should be reported to Apple.
+- **Social engineering** -- tricking a user into granting permissions or running malicious commands.
+- **Denial of service against the local machine** -- the server runs locally and is not exposed to the network by default.
+- **Vulnerabilities in upstream dependencies** -- report these to the relevant maintainers. If a dependency issue directly impacts orchard-mcp, include details on how.


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow (lint, build, test on `macos-latest` with Node 18)
- Replace SECURITY.md with expanded policy: GitHub private vulnerability reporting, project-specific scope, response timeline, out-of-scope section
- Add `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and link to Discussions
- Repo topics and Discussions were also enabled (already applied via API)

## Follow-up

After this merges and CI runs once, add `build-and-test` as a required status check in branch protection settings.

## Test plan

- [ ] CI workflow triggers and passes on this PR
- [ ] Issue template config renders correctly (no blank issue option, Discussions link visible)
- [ ] SECURITY.md renders correctly with advisory link