### PR TITLE
chore: bump zod to ^4.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "zod": "^3.25.0"
+        "zod": "^4.4.0"
       },
       "bin": {
         "orchard-mcp": "build/index.js"
@@ -1707,9 +1707,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "zod": "^3.25.0"
+    "zod": "^4.4.0"
   },
   "devDependencies": {
     "@types/node": "^25.0.0",


### PR DESCRIPTION
## Summary

Bumps `zod` from `^3.25.0` to `^4.4.0`.

## Migration impact

The codebase's zod surface is small and uses only methods unchanged between v3 and v4:
- `z.string()`, `z.number()`, `z.object()`
- `.optional()`, `.min()`, `.max()`, `.int()`, `.describe()`

None of the high-risk v4 breaking changes (`.email/.url/.uuid` moving to top-level, `z.record` 2-arg requirement, `.default()` semantics, error map shape) apply.

## Verification

- `tsc --noEmit` — clean
- `npm test` — 114/114 pass
- `npm run build` — Swift release + TS build both succeed
- `npm audit` — 0 vulnerabilities