### PR TITLE
feat: add module config and optional calendar/reminder age limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,13 @@ npm start              # Run the MCP server
 MCP Client (stdio JSON-RPC) -> TypeScript Server (Node.js) -> Swift CLI (apple-bridge) -> macOS Frameworks
 ```
 
-**Entry point:** `src/index.ts` creates `McpServer`, registers tools from 10 modules, connects `StdioServerTransport`, and handles the `orchard-mcp setup` subcommand before server startup.
+**Entry point:** `src/index.ts` loads config, registers tools from 10 modules via `src/registerTools.ts` (all enabled by default), connects `StdioServerTransport`, and handles the `orchard-mcp setup` subcommand before server startup.
+
+**Configuration:** `src/config.ts` reads optional `~/.config/orchard-mcp/config.json` (override with `ORCHARD_MCP_CONFIG`) and environment variables (`ORCHARD_MCP_MODULES`, `ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS`, `ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS`). Disabled modules are not registered. Calendar and reminder read tools apply optional age filters via `src/ageFilters.ts`.
 
 **Bridge layer:** `src/bridge.ts` executes the Swift binary, parses the `{status, data, error}` JSON envelope, and automatically retries via the `.app` bundle on "access denied" errors required for some macOS TCC permissions. `bridgeData(args)` is the convenience wrapper that throws on error.
 
-**Tool modules:** `src/tools/*.ts` each exports a `register*Tools(server)` function. Tools use `server.tool(name, description, zodSchema, asyncHandler)`. Tool names are namespaced: `calendar.*`, `mail.*`, `reminders.*`, `files.*`, `system.*`, `numbers.*`, `pages.*`, `keynote.*`, `notes.*`, `contacts.*`. 65 tools total.
+**Tool modules:** `src/tools/*.ts` each export a `register*Tools(server, config)` function. Tools use `server.tool(name, description, zodSchema, asyncHandler)`. Tool names are namespaced: `calendar.*`, `mail.*`, `reminders.*`, `files.*`, `system.*`, `numbers.*`, `pages.*`, `keynote.*`, `notes.*`, `contacts.*`. 65 tools total when all modules are enabled.
 
 **App Safety:** Tool modules must call `safeBridgeData(args, OPERATION_PROFILES.<profile>)` from `src/safety.ts`, not `bridgeData` directly. The safety layer serializes host-app lanes, applies queue/time/output budgets, and refuses broad requests before they can make Mail.app or other apps unresponsive. Keep [docs/app-safety-audit.md](docs/app-safety-audit.md) current when changing tool scope, timeouts, result limits, or app automation.
 
@@ -47,7 +49,7 @@ MCP Client (stdio JSON-RPC) -> TypeScript Server (Node.js) -> Swift CLI (apple-b
 - iWork tools (Numbers, Pages, Keynote) use AppleScript for document operations; Numbers bulk cell ops use JXA for native JSON
 - iWork file paths are validated via `FilesBridge.validatePath()` and must be under `~/`
 - Export subcommands use `--dest`, not `--output`, because `--output` is reserved for `.app` bundle mode JSON redirection
-- Environment overrides: `APPLE_BRIDGE_BIN`, `APPLE_BRIDGE_APP`
+- Environment overrides: `APPLE_BRIDGE_BIN`, `APPLE_BRIDGE_APP`, `ORCHARD_MCP_CONFIG`, `ORCHARD_MCP_MODULES`, `ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS`, `ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS`
 
 ## Requirements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Module configuration.** Restrict which tool modules are exposed via `~/.config/orchard-mcp/config.json` or `ORCHARD_MCP_MODULES`. Disabled modules are not registered, so their tools cannot be listed or invoked. Default: all 10 modules enabled.
+- **Optional age limits.** `calendarMaxAgeDays` and `remindersMaxAgeDays` (config file or env) hide calendar events and completed reminders older than the cutoff. Incomplete overdue reminders are always returned.
+
 ## [0.6.3] - 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -117,6 +117,66 @@ Add to your MCP settings:
 {"command": "npx", "args": ["@l22-io/orchard-mcp"]}
 ```
 
+## Configuration
+
+By default, orchard-mcp exposes all 65 tools. You can restrict which modules are enabled
+and optionally limit how far back calendar events and completed reminders are returned.
+
+### Config file
+
+Create `~/.config/orchard-mcp/config.json`:
+
+```json
+{
+  "modules": ["calendar", "reminders", "files", "system"],
+  "calendarMaxAgeDays": 365,
+  "remindersMaxAgeDays": 90
+}
+```
+
+Override the file path with `ORCHARD_MCP_CONFIG`.
+
+If the file omits `modules`, all modules remain enabled. Disabled modules are not
+registered with MCP, so their tools cannot be listed or called.
+
+Age limits are optional:
+
+- **Calendar** (`list_events`, `today`, `search`): events whose `end` is before the
+  cutoff are omitted.
+- **Reminders** (`list_reminders`, `today`): completed reminders whose `completionDate`
+  is before the cutoff are omitted. Incomplete reminders (including overdue items) are
+  always returned.
+
+### Environment variables
+
+Set these in your MCP client's `"env"` block (they override the config file):
+
+| Variable | Purpose |
+|----------|---------|
+| `ORCHARD_MCP_CONFIG` | Custom config file path |
+| `ORCHARD_MCP_MODULES` | Comma-separated module list (e.g. `calendar,mail,files`) |
+| `ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS` | Non-negative integer; unset = no limit |
+| `ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS` | Non-negative integer; unset = no limit |
+
+Example for Claude Desktop or Cursor:
+
+```json
+{
+  "mcpServers": {
+    "orchard": {
+      "command": "npx",
+      "args": ["@l22-io/orchard-mcp"],
+      "env": {
+        "ORCHARD_MCP_MODULES": "calendar,reminders,files,system"
+      }
+    }
+  }
+}
+```
+
+Valid module names: `calendar`, `mail`, `reminders`, `files`, `system`, `numbers`,
+`pages`, `keynote`, `notes`, `contacts`.
+
 ## Available Tools
 
 ### Calendar

--- a/src/ageFilters.ts
+++ b/src/ageFilters.ts
@@ -1,0 +1,80 @@
+export interface CalendarEventLike {
+  end: string;
+}
+
+export interface ReminderLike {
+  isCompleted: boolean;
+  completionDate?: string;
+}
+
+export function cutoffDate(maxAgeDays: number, now: Date = new Date()): Date {
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return new Date(startOfToday.getTime() - maxAgeDays * 86_400_000);
+}
+
+function parseIsoDate(value: string): Date | undefined {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return parsed;
+}
+
+export function isCalendarRangeFullyBeforeCutoff(
+  startISO: string,
+  endISO: string,
+  maxAgeDays: number | undefined,
+  now: Date = new Date()
+): boolean {
+  if (maxAgeDays === undefined) {
+    return false;
+  }
+  const end = parseIsoDate(endISO);
+  if (!end) {
+    return false;
+  }
+  const cutoff = cutoffDate(maxAgeDays, now);
+  return end.getTime() < cutoff.getTime();
+}
+
+export function filterCalendarEvents<T extends CalendarEventLike>(
+  events: T[],
+  maxAgeDays: number | undefined,
+  now: Date = new Date()
+): T[] {
+  if (maxAgeDays === undefined) {
+    return events;
+  }
+  const cutoff = cutoffDate(maxAgeDays, now);
+  return events.filter((event) => {
+    const end = parseIsoDate(event.end);
+    if (!end) {
+      return true;
+    }
+    return end.getTime() >= cutoff.getTime();
+  });
+}
+
+export function filterReminders<T extends ReminderLike>(
+  reminders: T[],
+  maxAgeDays: number | undefined,
+  now: Date = new Date()
+): T[] {
+  if (maxAgeDays === undefined) {
+    return reminders;
+  }
+  const cutoff = cutoffDate(maxAgeDays, now);
+  return reminders.filter((reminder) => {
+    if (!reminder.isCompleted) {
+      return true;
+    }
+    if (!reminder.completionDate) {
+      return true;
+    }
+    const completionDate = parseIsoDate(reminder.completionDate);
+    if (!completionDate) {
+      return true;
+    }
+    return completionDate.getTime() >= cutoff.getTime();
+  });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,12 +94,17 @@ function parseMaxAgeDays(
 }
 
 function readConfigFile(path: string): ConfigFile {
+  let parsed: unknown;
   try {
-    return JSON.parse(readFileSync(path, "utf8")) as ConfigFile;
+    parsed = JSON.parse(readFileSync(path, "utf8"));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to read config file ${path}: ${message}`);
   }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Failed to read config file ${path}: must be a JSON object, not ${parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed}.`);
+  }
+  return parsed as ConfigFile;
 }
 
 function loadConfigFile(): ConfigFile {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,169 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+export const ALL_MODULES = [
+  "calendar",
+  "mail",
+  "reminders",
+  "files",
+  "system",
+  "numbers",
+  "pages",
+  "keynote",
+  "notes",
+  "contacts",
+] as const;
+
+export type ModuleName = (typeof ALL_MODULES)[number];
+
+export interface OrchardConfig {
+  enabledModules: readonly ModuleName[];
+  calendarMaxAgeDays?: number;
+  remindersMaxAgeDays?: number;
+}
+
+interface ConfigFile {
+  modules?: unknown;
+  calendarMaxAgeDays?: unknown;
+  remindersMaxAgeDays?: unknown;
+}
+
+const DEFAULT_CONFIG_PATH = resolve(homedir(), ".config", "orchard-mcp", "config.json");
+
+function isModuleName(value: string): value is ModuleName {
+  return (ALL_MODULES as readonly string[]).includes(value);
+}
+
+function parseModules(value: unknown, source: string): ModuleName[] {
+  if (value === undefined) {
+    return [...ALL_MODULES];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${source}: "modules" must be an array of module names.`);
+  }
+  if (value.length === 0) {
+    throw new Error(
+      `${source}: "modules" must include at least one module. Valid modules: ${ALL_MODULES.join(", ")}`
+    );
+  }
+  const modules: ModuleName[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || !isModuleName(item)) {
+      throw new Error(
+        `${source}: unknown module "${String(item)}". Valid modules: ${ALL_MODULES.join(", ")}`
+      );
+    }
+    if (!modules.includes(item)) {
+      modules.push(item);
+    }
+  }
+  return modules;
+}
+
+function parseModulesFromEnv(value: string | undefined, source: string): ModuleName[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    throw new Error(
+      `${source}: must include at least one module. Valid modules: ${ALL_MODULES.join(", ")}`
+    );
+  }
+  const parts = trimmed.split(",").map((part) => part.trim()).filter(Boolean);
+  return parseModules(parts, source);
+}
+
+function parseMaxAgeDays(
+  value: unknown,
+  key: string,
+  source: string
+): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === "string" && value.trim() === "") {
+    return undefined;
+  }
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${source}: "${key}" must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function readConfigFile(path: string): ConfigFile {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as ConfigFile;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read config file ${path}: ${message}`);
+  }
+}
+
+function loadConfigFile(): ConfigFile {
+  const configPath = process.env.ORCHARD_MCP_CONFIG?.trim() || DEFAULT_CONFIG_PATH;
+  if (!existsSync(configPath)) {
+    return {};
+  }
+  return readConfigFile(configPath);
+}
+
+export function loadConfig(): OrchardConfig {
+  const fileConfig = loadConfigFile();
+  const configPath = process.env.ORCHARD_MCP_CONFIG?.trim() || DEFAULT_CONFIG_PATH;
+  const fileSource = existsSync(configPath) ? configPath : "config file";
+
+  const envModules = parseModulesFromEnv(
+    process.env.ORCHARD_MCP_MODULES,
+    "ORCHARD_MCP_MODULES"
+  );
+  const enabledModules =
+    envModules ?? parseModules(fileConfig.modules, fileSource);
+
+  const calendarMaxAgeDays =
+    parseMaxAgeDays(
+      process.env.ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS ?? fileConfig.calendarMaxAgeDays,
+      "calendarMaxAgeDays",
+      process.env.ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS !== undefined
+        ? "ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS"
+        : fileSource
+    );
+  const remindersMaxAgeDays =
+    parseMaxAgeDays(
+      process.env.ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS ?? fileConfig.remindersMaxAgeDays,
+      "remindersMaxAgeDays",
+      process.env.ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS !== undefined
+        ? "ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS"
+        : fileSource
+    );
+
+  return {
+    enabledModules,
+    calendarMaxAgeDays,
+    remindersMaxAgeDays,
+  };
+}
+
+export function logConfig(config: OrchardConfig): void {
+  console.error(
+    `[orchard-mcp] Enabled modules: ${config.enabledModules.join(", ")}`
+  );
+  const limits: string[] = [];
+  if (config.calendarMaxAgeDays !== undefined) {
+    limits.push(`calendarMaxAgeDays=${config.calendarMaxAgeDays}`);
+  }
+  if (config.remindersMaxAgeDays !== undefined) {
+    limits.push(`remindersMaxAgeDays=${config.remindersMaxAgeDays}`);
+  }
+  if (limits.length > 0) {
+    console.error(`[orchard-mcp] ${limits.join(", ")}`);
+  }
+}
+
+export function failConfig(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[orchard-mcp] Configuration error: ${message}`);
+  process.exit(1);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,32 +14,24 @@ if (process.argv[2] === "setup") {
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { registerCalendarTools } from "./tools/calendar.js";
-import { registerMailTools } from "./tools/mail.js";
-import { registerReminderTools } from "./tools/reminders.js";
-import { registerSystemTools } from "./tools/system.js";
-import { registerFileTools } from "./tools/files.js";
-import { registerNumbersTools } from "./tools/numbers.js";
-import { registerPagesTools } from "./tools/pages.js";
-import { registerKeynoteTools } from "./tools/keynote.js";
-import { registerNotesTools } from "./tools/notes.js";
-import { registerContactsTools } from "./tools/contacts.js";
+import { failConfig, loadConfig, logConfig } from "./config.js";
+import { registerEnabledTools } from "./registerTools.js";
+
+let config;
+try {
+  config = loadConfig();
+} catch (error) {
+  failConfig(error);
+}
+
+logConfig(config);
 
 const server = new McpServer({
   name: "orchard-mcp",
   version: packageJson.version,
 });
 
-registerCalendarTools(server);
-registerMailTools(server);
-registerReminderTools(server);
-registerSystemTools(server);
-registerFileTools(server);
-registerNumbersTools(server);
-registerPagesTools(server);
-registerKeynoteTools(server);
-registerNotesTools(server);
-registerContactsTools(server);
+registerEnabledTools(server, config);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/registerTools.ts
+++ b/src/registerTools.ts
@@ -1,0 +1,33 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { OrchardConfig, ModuleName } from "./config.js";
+import { registerCalendarTools } from "./tools/calendar.js";
+import { registerMailTools } from "./tools/mail.js";
+import { registerReminderTools } from "./tools/reminders.js";
+import { registerSystemTools } from "./tools/system.js";
+import { registerFileTools } from "./tools/files.js";
+import { registerNumbersTools } from "./tools/numbers.js";
+import { registerPagesTools } from "./tools/pages.js";
+import { registerKeynoteTools } from "./tools/keynote.js";
+import { registerNotesTools } from "./tools/notes.js";
+import { registerContactsTools } from "./tools/contacts.js";
+
+type ToolRegistrar = (server: McpServer, config: OrchardConfig) => void;
+
+const MODULE_REGISTRARS: Record<ModuleName, ToolRegistrar> = {
+  calendar: registerCalendarTools,
+  mail: registerMailTools,
+  reminders: registerReminderTools,
+  system: registerSystemTools,
+  files: registerFileTools,
+  numbers: registerNumbersTools,
+  pages: registerPagesTools,
+  keynote: registerKeynoteTools,
+  notes: registerNotesTools,
+  contacts: registerContactsTools,
+};
+
+export function registerEnabledTools(server: McpServer, config: OrchardConfig): void {
+  for (const name of config.enabledModules) {
+    MODULE_REGISTRARS[name](server, config);
+  }
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -321,6 +321,9 @@ async function printClientConfig(total: number): Promise<void> {
     log(`  Command: node`);
     log(`  Args: ${serverPath}`);
   }
+
+  log("Optional server config: ~/.config/orchard-mcp/config.json");
+  log("  Restrict modules or set calendar/reminder age limits (see README).");
 }
 
 // Step 6: Validation

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -1,11 +1,25 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import {
+  filterCalendarEvents,
+  isCalendarRangeFullyBeforeCutoff,
+} from "../ageFilters.js";
+import { OrchardConfig } from "../config.js";
 import { assertIsoDateRangeWithinDays } from "../resourceGuards.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
 const MAX_CALENDAR_RANGE_DAYS = 31;
 
-export function registerCalendarTools(server: McpServer): void {
+function formatEventsResponse(
+  data: unknown,
+  calendarMaxAgeDays: number | undefined
+): string {
+  const events = Array.isArray(data) ? data : [];
+  const filtered = filterCalendarEvents(events, calendarMaxAgeDays);
+  return JSON.stringify(filtered, null, 2);
+}
+
+export function registerCalendarTools(server: McpServer, config: OrchardConfig): void {
   server.tool(
     "calendar.list_calendars",
     "List all Apple Calendar calendars with account name, type, color, and read-only status.",
@@ -40,13 +54,23 @@ export function registerCalendarTools(server: McpServer): void {
         MAX_CALENDAR_RANGE_DAYS,
         "calendar.list_events"
       );
+      if (isCalendarRangeFullyBeforeCutoff(start, end, config.calendarMaxAgeDays)) {
+        return {
+          content: [{ type: "text", text: JSON.stringify([], null, 2) }],
+        };
+      }
       const args = ["events", "--start", start, "--end", end];
       if (calendarId) {
         args.push("--calendar", calendarId);
       }
       const data = await safeBridgeData(args, OPERATION_PROFILES.calendarRead);
       return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: formatEventsResponse(data, config.calendarMaxAgeDays),
+          },
+        ],
       };
     }
   );
@@ -76,7 +100,12 @@ export function registerCalendarTools(server: McpServer): void {
         OPERATION_PROFILES.calendarRead
       );
       return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: formatEventsResponse(data, config.calendarMaxAgeDays),
+          },
+        ],
       };
     }
   );
@@ -96,6 +125,11 @@ export function registerCalendarTools(server: McpServer): void {
         MAX_CALENDAR_RANGE_DAYS,
         "calendar.search"
       );
+      if (isCalendarRangeFullyBeforeCutoff(start, end, config.calendarMaxAgeDays)) {
+        return {
+          content: [{ type: "text", text: JSON.stringify([], null, 2) }],
+        };
+      }
       const data = await safeBridgeData([
         "search",
         query,
@@ -105,7 +139,12 @@ export function registerCalendarTools(server: McpServer): void {
         end,
       ], OPERATION_PROFILES.calendarRead);
       return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: formatEventsResponse(data, config.calendarMaxAgeDays),
+          },
+        ],
       };
     }
   );

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerContactsTools(server: McpServer): void {
+export function registerContactsTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "contacts.list_groups",
     "List all contact groups with member counts. Requires Contacts access.",

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -1,9 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { assertBatchSize } from "../resourceGuards.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerFileTools(server: McpServer): void {
+export function registerFileTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "files.list",
     "List directory contents with metadata (name, size, dates, type). Paths relative to home directory.",

--- a/src/tools/keynote.ts
+++ b/src/tools/keynote.ts
@@ -1,9 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { requireKeynoteSlideForImageExport } from "../resourceGuards.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerKeynoteTools(server: McpServer): void {
+export function registerKeynoteTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "keynote.search",
     "Search for Keynote presentation files by name.",

--- a/src/tools/mail.ts
+++ b/src/tools/mail.ts
@@ -1,9 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { appendMailLocatorArgs, requireMailLocator } from "../mailSafety.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerMailTools(server: McpServer): void {
+export function registerMailTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "mail.list_accounts",
     "List all Apple Mail accounts with a bounded sample of mailbox names. Per-mailbox unread counts are intentionally omitted so account listing does not recursively scan Mail.app; use mail.unread_summary for unread counts. Requires Mail.app to be running.",

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -1,9 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { normalizeNotesSearchIn } from "../resourceGuards.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerNotesTools(server: McpServer): void {
+export function registerNotesTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "notes.list_folders",
     "List all Notes folders grouped by account with note counts. Requires Notes.app to be running and Automation permission.",

--- a/src/tools/numbers.ts
+++ b/src/tools/numbers.ts
@@ -1,9 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { requireNumbersRange } from "../resourceGuards.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerNumbersTools(server: McpServer): void {
+export function registerNumbersTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "numbers.search",
     "Search for Numbers spreadsheet files by name or content.",

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerPagesTools(server: McpServer): void {
+export function registerPagesTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "pages.search",
     "Search for Pages document files by name or content.",

--- a/src/tools/reminders.ts
+++ b/src/tools/reminders.ts
@@ -1,8 +1,19 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { filterReminders } from "../ageFilters.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerReminderTools(server: McpServer): void {
+function formatRemindersResponse(
+  data: unknown,
+  remindersMaxAgeDays: number | undefined
+): string {
+  const reminders = Array.isArray(data) ? data : [];
+  const filtered = filterReminders(reminders, remindersMaxAgeDays);
+  return JSON.stringify(filtered, null, 2);
+}
+
+export function registerReminderTools(server: McpServer, config: OrchardConfig): void {
   server.tool(
     "reminders.list_lists",
     "List all Apple Reminders lists with account name, color, and modification status.",
@@ -51,7 +62,12 @@ export function registerReminderTools(server: McpServer): void {
       }
       const data = await safeBridgeData(args, OPERATION_PROFILES.remindersRead);
       return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: formatRemindersResponse(data, config.remindersMaxAgeDays),
+          },
+        ],
       };
     }
   );
@@ -66,7 +82,12 @@ export function registerReminderTools(server: McpServer): void {
         OPERATION_PROFILES.remindersRead
       );
       return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: formatRemindersResponse(data, config.remindersMaxAgeDays),
+          },
+        ],
       };
     }
   );

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1,7 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerSystemTools(server: McpServer): void {
+export function registerSystemTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "system.doctor",
     "Check orchard-mcp permissions status, list accessible Calendar accounts, Mail accounts, and Reminders status. Run this first to diagnose access issues.",

--- a/tests/age-filters.test.ts
+++ b/tests/age-filters.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  cutoffDate,
+  filterCalendarEvents,
+  filterReminders,
+  isCalendarRangeFullyBeforeCutoff,
+} from "../src/ageFilters.js";
+
+const NOW = new Date("2026-06-18T15:00:00");
+
+describe("age filters", () => {
+  it("computes cutoff as start of today minus maxAgeDays", () => {
+    const cutoff = cutoffDate(30, NOW);
+    const expected = new Date(NOW.getFullYear(), NOW.getMonth(), NOW.getDate());
+    expected.setDate(expected.getDate() - 30);
+    assert.equal(cutoff.getTime(), expected.getTime());
+  });
+
+  it("returns false when maxAgeDays is undefined", () => {
+    assert.equal(
+      isCalendarRangeFullyBeforeCutoff("2020-01-01", "2020-01-02", undefined, NOW),
+      false
+    );
+  });
+
+  it("detects calendar ranges fully before the cutoff", () => {
+    assert.equal(
+      isCalendarRangeFullyBeforeCutoff("2020-01-01", "2020-01-02", 30, NOW),
+      true
+    );
+    assert.equal(
+      isCalendarRangeFullyBeforeCutoff("2026-06-01", "2026-06-18", 30, NOW),
+      false
+    );
+  });
+
+  it("filters calendar events by end date", () => {
+    const events = [
+      { id: "old", end: "2020-01-01T10:00:00Z" },
+      { id: "recent", end: "2026-06-18T10:00:00Z" },
+      { id: "future", end: "2026-07-01T10:00:00Z" },
+    ];
+
+    const filtered = filterCalendarEvents(events, 30, NOW);
+    assert.deepEqual(
+      filtered.map((event) => event.id),
+      ["recent", "future"]
+    );
+  });
+
+  it("keeps calendar events when maxAgeDays is undefined", () => {
+    const events = [{ id: "old", end: "2020-01-01T10:00:00Z" }];
+    assert.deepEqual(filterCalendarEvents(events, undefined, NOW), events);
+  });
+
+  it("filters old completed reminders but keeps incomplete overdue items", () => {
+    const reminders = [
+      {
+        id: "old-completed",
+        isCompleted: true,
+        completionDate: "2020-01-01T10:00:00Z",
+      },
+      {
+        id: "recent-completed",
+        isCompleted: true,
+        completionDate: "2026-06-10T10:00:00Z",
+      },
+      {
+        id: "overdue-incomplete",
+        isCompleted: false,
+        dueDate: "2020-01-01T10:00:00Z",
+      },
+      {
+        id: "undated-incomplete",
+        isCompleted: false,
+      },
+      {
+        id: "completed-no-date",
+        isCompleted: true,
+      },
+    ];
+
+    const filtered = filterReminders(reminders, 30, NOW);
+    assert.deepEqual(
+      filtered.map((reminder) => reminder.id),
+      [
+        "recent-completed",
+        "overdue-incomplete",
+        "undated-incomplete",
+        "completed-no-date",
+      ]
+    );
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -127,4 +127,16 @@ describe("config loading", () => {
 
     assert.throws(() => loadConfig(), /Failed to read config file/);
   });
+
+  it("rejects config file that contains null instead of an object", () => {
+    writeFileSync(process.env.ORCHARD_MCP_CONFIG!, "null");
+
+    assert.throws(() => loadConfig(), /Failed to read config file.*null/);
+  });
+
+  it("rejects config file that contains a JSON array instead of an object", () => {
+    writeFileSync(process.env.ORCHARD_MCP_CONFIG!, '["calendar"]');
+
+    assert.throws(() => loadConfig(), /Failed to read config file.*array/);
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig, ALL_MODULES } from "../src/config.js";
+
+const ENV_KEYS = [
+  "ORCHARD_MCP_CONFIG",
+  "ORCHARD_MCP_MODULES",
+  "ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS",
+  "ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS",
+] as const;
+
+describe("config loading", () => {
+  let savedEnv: Record<string, string | undefined>;
+  let tempDir: string;
+
+  beforeEach(() => {
+    savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+    tempDir = mkdtempSync(join(tmpdir(), "orchard-mcp-config-"));
+    process.env.ORCHARD_MCP_CONFIG = join(tempDir, "config.json");
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("defaults to all modules with no age limits when config file is missing", () => {
+    const config = loadConfig();
+    assert.deepEqual(config.enabledModules, ALL_MODULES);
+    assert.equal(config.calendarMaxAgeDays, undefined);
+    assert.equal(config.remindersMaxAgeDays, undefined);
+  });
+
+  it("loads modules and age limits from config file", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({
+        modules: ["calendar", "mail", "system"],
+        calendarMaxAgeDays: 365,
+        remindersMaxAgeDays: 90,
+      })
+    );
+
+    const config = loadConfig();
+    assert.deepEqual(config.enabledModules, ["calendar", "mail", "system"]);
+    assert.equal(config.calendarMaxAgeDays, 365);
+    assert.equal(config.remindersMaxAgeDays, 90);
+  });
+
+  it("defaults modules to all when config file omits modules key", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({ calendarMaxAgeDays: 30 })
+    );
+
+    const config = loadConfig();
+    assert.deepEqual(config.enabledModules, ALL_MODULES);
+    assert.equal(config.calendarMaxAgeDays, 30);
+  });
+
+  it("lets environment variables override config file values", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({
+        modules: ["calendar"],
+        calendarMaxAgeDays: 10,
+        remindersMaxAgeDays: 20,
+      })
+    );
+    process.env.ORCHARD_MCP_MODULES = "mail, files";
+    process.env.ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS = "100";
+    process.env.ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS = "200";
+
+    const config = loadConfig();
+    assert.deepEqual(config.enabledModules, ["mail", "files"]);
+    assert.equal(config.calendarMaxAgeDays, 100);
+    assert.equal(config.remindersMaxAgeDays, 200);
+  });
+
+  it("rejects unknown module names", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({ modules: ["calendar", "not-a-module"] })
+    );
+
+    assert.throws(() => loadConfig(), /unknown module "not-a-module"/);
+  });
+
+  it("rejects empty modules array in config file", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({ modules: [] })
+    );
+
+    assert.throws(() => loadConfig(), /must include at least one module/);
+  });
+
+  it("rejects empty ORCHARD_MCP_MODULES env var", () => {
+    process.env.ORCHARD_MCP_MODULES = "";
+
+    assert.throws(() => loadConfig(), /ORCHARD_MCP_MODULES.*must include at least one module/);
+  });
+
+  it("rejects invalid age values", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({ calendarMaxAgeDays: -1 })
+    );
+
+    assert.throws(() => loadConfig(), /calendarMaxAgeDays.*non-negative integer/);
+  });
+
+  it("rejects malformed config JSON", () => {
+    writeFileSync(process.env.ORCHARD_MCP_CONFIG!, "{not json");
+
+    assert.throws(() => loadConfig(), /Failed to read config file/);
+  });
+});

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -2,16 +2,8 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { registerCalendarTools } from "../src/tools/calendar.js";
-import { registerContactsTools } from "../src/tools/contacts.js";
-import { registerFileTools } from "../src/tools/files.js";
-import { registerKeynoteTools } from "../src/tools/keynote.js";
-import { registerMailTools } from "../src/tools/mail.js";
-import { registerNotesTools } from "../src/tools/notes.js";
-import { registerNumbersTools } from "../src/tools/numbers.js";
-import { registerPagesTools } from "../src/tools/pages.js";
-import { registerReminderTools } from "../src/tools/reminders.js";
-import { registerSystemTools } from "../src/tools/system.js";
+import { ALL_MODULES } from "../src/config.js";
+import { registerEnabledTools } from "../src/registerTools.js";
 
 const repoRoot = new URL("../", import.meta.url);
 
@@ -27,16 +19,7 @@ const packageJson = JSON.parse(readRepoFile("package.json")) as {
 
 function registeredToolCount(): number {
   const server = new McpServer({ name: "orchard-mcp", version: packageJson.version });
-  registerCalendarTools(server);
-  registerMailTools(server);
-  registerReminderTools(server);
-  registerSystemTools(server);
-  registerFileTools(server);
-  registerNumbersTools(server);
-  registerPagesTools(server);
-  registerKeynoteTools(server);
-  registerNotesTools(server);
-  registerContactsTools(server);
+  registerEnabledTools(server, { enabledModules: ALL_MODULES });
   return Object.keys((server as any)._registeredTools as Record<string, unknown>).length;
 }
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -2,20 +2,16 @@ import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { registerCalendarTools } from "../src/tools/calendar.js";
-import { registerMailTools } from "../src/tools/mail.js";
-import { registerReminderTools } from "../src/tools/reminders.js";
-import { registerSystemTools } from "../src/tools/system.js";
-import { registerFileTools } from "../src/tools/files.js";
-import { registerNumbersTools } from "../src/tools/numbers.js";
-import { registerPagesTools } from "../src/tools/pages.js";
-import { registerKeynoteTools } from "../src/tools/keynote.js";
-import { registerNotesTools } from "../src/tools/notes.js";
-import { registerContactsTools } from "../src/tools/contacts.js";
+import { ALL_MODULES, OrchardConfig } from "../src/config.js";
+import { registerEnabledTools } from "../src/registerTools.js";
 
 const packageJson = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8")
 ) as { version: string };
+
+const DEFAULT_CONFIG: OrchardConfig = {
+  enabledModules: ALL_MODULES,
+};
 
 const EXPECTED_TOOLS = [
   // Calendar (4)
@@ -95,26 +91,21 @@ const EXPECTED_TOOLS = [
   "contacts.read_contact",
 ];
 
+function registeredToolNames(server: McpServer): string[] {
+  const tools = (server as any)._registeredTools as Record<string, unknown>;
+  return Object.keys(tools);
+}
+
 describe("tool registration", () => {
   let server: McpServer;
 
   before(() => {
     server = new McpServer({ name: "orchard-mcp", version: packageJson.version });
-    registerCalendarTools(server);
-    registerMailTools(server);
-    registerReminderTools(server);
-    registerSystemTools(server);
-    registerFileTools(server);
-    registerNumbersTools(server);
-    registerPagesTools(server);
-    registerKeynoteTools(server);
-    registerNotesTools(server);
-    registerContactsTools(server);
+    registerEnabledTools(server, DEFAULT_CONFIG);
   });
 
   it("registers exactly 65 tools", () => {
-    const tools = (server as any)._registeredTools as Record<string, unknown>;
-    const names = Object.keys(tools);
+    const names = registeredToolNames(server);
     assert.equal(names.length, 65, `Expected 65 tools, got ${names.length}: ${names.join(", ")}`);
   });
 
@@ -124,4 +115,19 @@ describe("tool registration", () => {
       assert.ok(name in tools, `Tool "${name}" not registered`);
     });
   }
+
+  it("registers only enabled modules", () => {
+    const restrictedServer = new McpServer({
+      name: "orchard-mcp",
+      version: packageJson.version,
+    });
+    registerEnabledTools(restrictedServer, {
+      enabledModules: ["calendar", "system"],
+    });
+
+    const names = registeredToolNames(restrictedServer);
+    assert.equal(names.length, 5);
+    assert.ok(names.every((name) => name.startsWith("calendar.") || name.startsWith("system.")));
+    assert.ok(!names.some((name) => name.startsWith("mail.")));
+  });
 });


### PR DESCRIPTION
## Summary
- Add optional server configuration via `~/.config/orchard-mcp/config.json` and `ORCHARD_MCP_*` environment variables to restrict which tool modules are exposed.
- Disabled modules are not registered with MCP, so their tools cannot be listed or invoked even when called directly.
- Add optional `calendarMaxAgeDays` and `remindersMaxAgeDays` limits that filter calendar read results and old completed reminders; incomplete overdue reminders remain visible.

## Test plan
- [x] `npm run lint`
- [x] `npm test` (170 tests pass)
- [x] Default config still exposes all 65 tools
- [x] Restricted `ORCHARD_MCP_MODULES` omits disabled tools from `tools/list` and rejects direct `tools/call`
- [x] `calendarMaxAgeDays` hides past events older than the cutoff
- [x] `remindersMaxAgeDays` hides old completed reminders but keeps incomplete overdue items