### PR TITLE
feat: add calendar.create_event tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ MCP Client (stdio JSON-RPC) -> TypeScript Server (Node.js) -> Swift CLI (apple-b
 
 **Bridge layer:** `src/bridge.ts` executes the Swift binary, parses the `{status, data, error}` JSON envelope, and automatically retries via the `.app` bundle on "access denied" errors required for some macOS TCC permissions. `bridgeData(args)` is the convenience wrapper that throws on error.
 
-**Tool modules:** `src/tools/*.ts` each export a `register*Tools(server, config)` function. Tools use `server.tool(name, description, zodSchema, asyncHandler)`. Tool names are namespaced: `calendar.*`, `mail.*`, `reminders.*`, `files.*`, `system.*`, `numbers.*`, `pages.*`, `keynote.*`, `notes.*`, `contacts.*`. 65 tools total when all modules are enabled.
+**Tool modules:** `src/tools/*.ts` each export a `register*Tools(server, config)` function. Tools use `server.tool(name, description, zodSchema, asyncHandler)`. Tool names are namespaced: `calendar.*`, `mail.*`, `reminders.*`, `files.*`, `system.*`, `numbers.*`, `pages.*`, `keynote.*`, `notes.*`, `contacts.*`. 66 tools total when all modules are enabled.
 
 **App Safety:** Tool modules must call `safeBridgeData(args, OPERATION_PROFILES.<profile>)` from `src/safety.ts`, not `bridgeData` directly. The safety layer serializes host-app lanes, applies queue/time/output budgets, and refuses broad requests before they can make Mail.app or other apps unresponsive. Keep [docs/app-safety-audit.md](docs/app-safety-audit.md) current when changing tool scope, timeouts, result limits, or app automation.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,13 @@ npm start              # Run the MCP server
 MCP Client (stdio JSON-RPC) -> TypeScript Server (Node.js) -> Swift CLI (apple-bridge) -> macOS Frameworks
 ```
 
-**Entry point:** `src/index.ts` creates `McpServer`, registers tools from 10 modules, connects `StdioServerTransport`, and handles the `orchard-mcp setup` subcommand before server startup.
+**Entry point:** `src/index.ts` loads config, registers tools from 10 modules via `src/registerTools.ts` (all enabled by default), connects `StdioServerTransport`, and handles the `orchard-mcp setup` subcommand before server startup.
+
+**Configuration:** `src/config.ts` reads optional `~/.config/orchard-mcp/config.json` (override with `ORCHARD_MCP_CONFIG`) and environment variables (`ORCHARD_MCP_MODULES`, `ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS`, `ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS`). Disabled modules are not registered. Calendar and reminder read tools apply optional age filters via `src/ageFilters.ts`.
 
 **Bridge layer:** `src/bridge.ts` executes the Swift binary, parses the `{status, data, error}` JSON envelope, and automatically retries via the `.app` bundle on "access denied" errors required for some macOS TCC permissions. `bridgeData(args)` is the convenience wrapper that throws on error.
 
-**Tool modules:** `src/tools/*.ts` each exports a `register*Tools(server)` function. Tools use `server.tool(name, description, zodSchema, asyncHandler)`. Tool names are namespaced: `calendar.*`, `mail.*`, `reminders.*`, `files.*`, `system.*`, `numbers.*`, `pages.*`, `keynote.*`, `notes.*`, `contacts.*`. 65 tools total.
+**Tool modules:** `src/tools/*.ts` each export a `register*Tools(server, config)` function. Tools use `server.tool(name, description, zodSchema, asyncHandler)`. Tool names are namespaced: `calendar.*`, `mail.*`, `reminders.*`, `files.*`, `system.*`, `numbers.*`, `pages.*`, `keynote.*`, `notes.*`, `contacts.*`. 65 tools total when all modules are enabled.
 
 **App Safety:** Tool modules must call `safeBridgeData(args, OPERATION_PROFILES.<profile>)` from `src/safety.ts`, not `bridgeData` directly. The safety layer serializes host-app lanes, applies queue/time/output budgets, and refuses broad requests before they can make Mail.app or other apps unresponsive. Keep [docs/app-safety-audit.md](docs/app-safety-audit.md) current when changing tool scope, timeouts, result limits, or app automation.
 
@@ -47,7 +49,7 @@ MCP Client (stdio JSON-RPC) -> TypeScript Server (Node.js) -> Swift CLI (apple-b
 - iWork tools (Numbers, Pages, Keynote) use AppleScript for document operations; Numbers bulk cell ops use JXA for native JSON
 - iWork file paths are validated via `FilesBridge.validatePath()` and must be under `~/`
 - Export subcommands use `--dest`, not `--output`, because `--output` is reserved for `.app` bundle mode JSON redirection
-- Environment overrides: `APPLE_BRIDGE_BIN`, `APPLE_BRIDGE_APP`
+- Environment overrides: `APPLE_BRIDGE_BIN`, `APPLE_BRIDGE_APP`, `ORCHARD_MCP_CONFIG`, `ORCHARD_MCP_MODULES`, `ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS`, `ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS`
 
 ## Requirements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Module configuration.** Restrict which tool modules are exposed via `~/.config/orchard-mcp/config.json` or `ORCHARD_MCP_MODULES`. Disabled modules are not registered, so their tools cannot be listed or invoked. Default: all 10 modules enabled.
+- **Optional age limits.** `calendarMaxAgeDays` and `remindersMaxAgeDays` (config file or env) hide calendar events and completed reminders older than the cutoff. Incomplete overdue reminders are always returned.
+
 ## [0.6.3] - 2026-05-27
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ The TypeScript layer spawns the Swift binary via `child_process.spawn` and parse
 npm test
 ```
 
-Tests cover tool registration (all 65 tools), metadata drift, bridge JSON contract validation, and focused argument/guard logic. Manual testing on macOS is required for end-to-end verification since EventKit, Contacts, AppleScript, JXA, and TCC permissions access real system data.
+Tests cover tool registration (all 66 tools), metadata drift, bridge JSON contract validation, and focused argument/guard logic. Manual testing on macOS is required for end-to-end verification since EventKit, Contacts, AppleScript, JXA, and TCC permissions access real system data.
 
 ### macOS Sequoia TCC Note
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,66 @@ Add to your MCP settings:
 {"command": "npx", "args": ["@l22-io/orchard-mcp"]}
 ```
 
+## Configuration
+
+By default, orchard-mcp exposes all 65 tools. You can restrict which modules are enabled
+and optionally limit how far back calendar events and completed reminders are returned.
+
+### Config file
+
+Create `~/.config/orchard-mcp/config.json`:
+
+```json
+{
+  "modules": ["calendar", "reminders", "files", "system"],
+  "calendarMaxAgeDays": 365,
+  "remindersMaxAgeDays": 90
+}
+```
+
+Override the file path with `ORCHARD_MCP_CONFIG`.
+
+If the file omits `modules`, all modules remain enabled. Disabled modules are not
+registered with MCP, so their tools cannot be listed or called.
+
+Age limits are optional:
+
+- **Calendar** (`list_events`, `today`, `search`): events whose `end` is before the
+  cutoff are omitted.
+- **Reminders** (`list_reminders`, `today`): completed reminders whose `completionDate`
+  is before the cutoff are omitted. Incomplete reminders (including overdue items) are
+  always returned.
+
+### Environment variables
+
+Set these in your MCP client's `"env"` block (they override the config file):
+
+| Variable | Purpose |
+|----------|---------|
+| `ORCHARD_MCP_CONFIG` | Custom config file path |
+| `ORCHARD_MCP_MODULES` | Comma-separated module list (e.g. `calendar,mail,files`) |
+| `ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS` | Non-negative integer; unset = no limit |
+| `ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS` | Non-negative integer; unset = no limit |
+
+Example for Claude Desktop or Cursor:
+
+```json
+{
+  "mcpServers": {
+    "orchard": {
+      "command": "npx",
+      "args": ["@l22-io/orchard-mcp"],
+      "env": {
+        "ORCHARD_MCP_MODULES": "calendar,reminders,files,system"
+      }
+    }
+  }
+}
+```
+
+Valid module names: `calendar`, `mail`, `reminders`, `files`, `system`, `numbers`,
+`pages`, `keynote`, `notes`, `contacts`.
+
 ## Available Tools
 
 ### Calendar

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Calendars"), triggered automatically on first use or during setup.
 
 ## Status
 
-Current release: 65 tools across Calendar, Mail, Reminders, Files, System, Numbers,
+Current release: 66 tools across Calendar, Mail, Reminders, Files, System, Numbers,
 Pages, Keynote, Notes, and Contacts. See [CHANGELOG.md](CHANGELOG.md) for release
 history.
 
@@ -119,7 +119,7 @@ Add to your MCP settings:
 
 ## Configuration
 
-By default, orchard-mcp exposes all 65 tools. You can restrict which modules are enabled
+By default, orchard-mcp exposes all 66 tools. You can restrict which modules are enabled
 and optionally limit how far back calendar events and completed reminders are returned.
 
 ### Config file
@@ -185,6 +185,7 @@ Valid module names: `calendar`, `mail`, `reminders`, `files`, `system`, `numbers
 - `calendar.list_events` - Events in a date range (recurring events expanded)
 - `calendar.today` - Today's events across all calendars
 - `calendar.search` - Search events by title, notes, or location
+- `calendar.create_event` - Create a new calendar event
 
 ### Mail
 
@@ -295,6 +296,7 @@ attached to the app bundle. Direct binary execution is still available through
 apple-bridge calendars
 apple-bridge events
 apple-bridge search
+apple-bridge event-create
 apple-bridge mail-accounts
 apple-bridge mail-unread
 apple-bridge mail-search

--- a/docs/app-safety-audit.md
+++ b/docs/app-safety-audit.md
@@ -20,7 +20,7 @@ orchard-mcp must protect the user's Mac first. A tool call is allowed to return 
 | Numbers | Numbers via AppleScript/JXA | `numbers.read` and `numbers.get_formulas` require an explicit cell range. Full-table reads are refused. |
 | Pages | Pages via AppleScript | Calls are serialized through the Pages lane and bounded by timeout/output budgets. Large writes/tables are capped by schema. |
 | Keynote | Keynote via AppleScript | PNG/JPEG export requires a slide index. All-slide image export is refused. Calls are serialized through the Keynote lane. |
-| Calendar | EventKit | `calendar.list_events` and `calendar.search` refuse ranges over 31 days; the native bridge also caps date ranges and result counts. |
+| Calendar | EventKit | `calendar.list_events` and `calendar.search` refuse ranges over 31 days; the native bridge also caps date ranges and result counts. `calendar.create_event` validates calendar modifiability before save and runs through the Calendar lane. |
 | Reminders | EventKit | List calls have bounded result limits in the schema and native bridge, and run through the Reminders lane. |
 | Contacts | Contacts.framework | Calls run through the Contacts lane and output budget. Phone substring fallback stops after a native scan budget. |
 | Files | FileManager, Spotlight, PDFKit, Vision, textutil | Calls run through the Files lane. `files.move` accepts at most 50 items per call. `mdfind`, `mdls`, and `textutil` use native subprocess timeouts. PDF, OCR, directory listing, and textutil extraction have native size/page/item budgets. |

--- a/src/ageFilters.ts
+++ b/src/ageFilters.ts
@@ -1,0 +1,80 @@
+export interface CalendarEventLike {
+  end: string;
+}
+
+export interface ReminderLike {
+  isCompleted: boolean;
+  completionDate?: string;
+}
+
+export function cutoffDate(maxAgeDays: number, now: Date = new Date()): Date {
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return new Date(startOfToday.getTime() - maxAgeDays * 86_400_000);
+}
+
+function parseIsoDate(value: string): Date | undefined {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return parsed;
+}
+
+export function isCalendarRangeFullyBeforeCutoff(
+  startISO: string,
+  endISO: string,
+  maxAgeDays: number | undefined,
+  now: Date = new Date()
+): boolean {
+  if (maxAgeDays === undefined) {
+    return false;
+  }
+  const end = parseIsoDate(endISO);
+  if (!end) {
+    return false;
+  }
+  const cutoff = cutoffDate(maxAgeDays, now);
+  return end.getTime() < cutoff.getTime();
+}
+
+export function filterCalendarEvents<T extends CalendarEventLike>(
+  events: T[],
+  maxAgeDays: number | undefined,
+  now: Date = new Date()
+): T[] {
+  if (maxAgeDays === undefined) {
+    return events;
+  }
+  const cutoff = cutoffDate(maxAgeDays, now);
+  return events.filter((event) => {
+    const end = parseIsoDate(event.end);
+    if (!end) {
+      return true;
+    }
+    return end.getTime() >= cutoff.getTime();
+  });
+}
+
+export function filterReminders<T extends ReminderLike>(
+  reminders: T[],
+  maxAgeDays: number | undefined,
+  now: Date = new Date()
+): T[] {
+  if (maxAgeDays === undefined) {
+    return reminders;
+  }
+  const cutoff = cutoffDate(maxAgeDays, now);
+  return reminders.filter((reminder) => {
+    if (!reminder.isCompleted) {
+      return true;
+    }
+    if (!reminder.completionDate) {
+      return true;
+    }
+    const completionDate = parseIsoDate(reminder.completionDate);
+    if (!completionDate) {
+      return true;
+    }
+    return completionDate.getTime() >= cutoff.getTime();
+  });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,12 +94,17 @@ function parseMaxAgeDays(
 }
 
 function readConfigFile(path: string): ConfigFile {
+  let parsed: unknown;
   try {
-    return JSON.parse(readFileSync(path, "utf8")) as ConfigFile;
+    parsed = JSON.parse(readFileSync(path, "utf8"));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to read config file ${path}: ${message}`);
   }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Failed to read config file ${path}: must be a JSON object, not ${parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed}.`);
+  }
+  return parsed as ConfigFile;
 }
 
 function loadConfigFile(): ConfigFile {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,169 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+export const ALL_MODULES = [
+  "calendar",
+  "mail",
+  "reminders",
+  "files",
+  "system",
+  "numbers",
+  "pages",
+  "keynote",
+  "notes",
+  "contacts",
+] as const;
+
+export type ModuleName = (typeof ALL_MODULES)[number];
+
+export interface OrchardConfig {
+  enabledModules: readonly ModuleName[];
+  calendarMaxAgeDays?: number;
+  remindersMaxAgeDays?: number;
+}
+
+interface ConfigFile {
+  modules?: unknown;
+  calendarMaxAgeDays?: unknown;
+  remindersMaxAgeDays?: unknown;
+}
+
+const DEFAULT_CONFIG_PATH = resolve(homedir(), ".config", "orchard-mcp", "config.json");
+
+function isModuleName(value: string): value is ModuleName {
+  return (ALL_MODULES as readonly string[]).includes(value);
+}
+
+function parseModules(value: unknown, source: string): ModuleName[] {
+  if (value === undefined) {
+    return [...ALL_MODULES];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${source}: "modules" must be an array of module names.`);
+  }
+  if (value.length === 0) {
+    throw new Error(
+      `${source}: "modules" must include at least one module. Valid modules: ${ALL_MODULES.join(", ")}`
+    );
+  }
+  const modules: ModuleName[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || !isModuleName(item)) {
+      throw new Error(
+        `${source}: unknown module "${String(item)}". Valid modules: ${ALL_MODULES.join(", ")}`
+      );
+    }
+    if (!modules.includes(item)) {
+      modules.push(item);
+    }
+  }
+  return modules;
+}
+
+function parseModulesFromEnv(value: string | undefined, source: string): ModuleName[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    throw new Error(
+      `${source}: must include at least one module. Valid modules: ${ALL_MODULES.join(", ")}`
+    );
+  }
+  const parts = trimmed.split(",").map((part) => part.trim()).filter(Boolean);
+  return parseModules(parts, source);
+}
+
+function parseMaxAgeDays(
+  value: unknown,
+  key: string,
+  source: string
+): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === "string" && value.trim() === "") {
+    return undefined;
+  }
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${source}: "${key}" must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function readConfigFile(path: string): ConfigFile {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as ConfigFile;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read config file ${path}: ${message}`);
+  }
+}
+
+function loadConfigFile(): ConfigFile {
+  const configPath = process.env.ORCHARD_MCP_CONFIG?.trim() || DEFAULT_CONFIG_PATH;
+  if (!existsSync(configPath)) {
+    return {};
+  }
+  return readConfigFile(configPath);
+}
+
+export function loadConfig(): OrchardConfig {
+  const fileConfig = loadConfigFile();
+  const configPath = process.env.ORCHARD_MCP_CONFIG?.trim() || DEFAULT_CONFIG_PATH;
+  const fileSource = existsSync(configPath) ? configPath : "config file";
+
+  const envModules = parseModulesFromEnv(
+    process.env.ORCHARD_MCP_MODULES,
+    "ORCHARD_MCP_MODULES"
+  );
+  const enabledModules =
+    envModules ?? parseModules(fileConfig.modules, fileSource);
+
+  const calendarMaxAgeDays =
+    parseMaxAgeDays(
+      process.env.ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS ?? fileConfig.calendarMaxAgeDays,
+      "calendarMaxAgeDays",
+      process.env.ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS !== undefined
+        ? "ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS"
+        : fileSource
+    );
+  const remindersMaxAgeDays =
+    parseMaxAgeDays(
+      process.env.ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS ?? fileConfig.remindersMaxAgeDays,
+      "remindersMaxAgeDays",
+      process.env.ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS !== undefined
+        ? "ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS"
+        : fileSource
+    );
+
+  return {
+    enabledModules,
+    calendarMaxAgeDays,
+    remindersMaxAgeDays,
+  };
+}
+
+export function logConfig(config: OrchardConfig): void {
+  console.error(
+    `[orchard-mcp] Enabled modules: ${config.enabledModules.join(", ")}`
+  );
+  const limits: string[] = [];
+  if (config.calendarMaxAgeDays !== undefined) {
+    limits.push(`calendarMaxAgeDays=${config.calendarMaxAgeDays}`);
+  }
+  if (config.remindersMaxAgeDays !== undefined) {
+    limits.push(`remindersMaxAgeDays=${config.remindersMaxAgeDays}`);
+  }
+  if (limits.length > 0) {
+    console.error(`[orchard-mcp] ${limits.join(", ")}`);
+  }
+}
+
+export function failConfig(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[orchard-mcp] Configuration error: ${message}`);
+  process.exit(1);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,32 +14,24 @@ if (process.argv[2] === "setup") {
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { registerCalendarTools } from "./tools/calendar.js";
-import { registerMailTools } from "./tools/mail.js";
-import { registerReminderTools } from "./tools/reminders.js";
-import { registerSystemTools } from "./tools/system.js";
-import { registerFileTools } from "./tools/files.js";
-import { registerNumbersTools } from "./tools/numbers.js";
-import { registerPagesTools } from "./tools/pages.js";
-import { registerKeynoteTools } from "./tools/keynote.js";
-import { registerNotesTools } from "./tools/notes.js";
-import { registerContactsTools } from "./tools/contacts.js";
+import { failConfig, loadConfig, logConfig } from "./config.js";
+import { registerEnabledTools } from "./registerTools.js";
+
+let config;
+try {
+  config = loadConfig();
+} catch (error) {
+  failConfig(error);
+}
+
+logConfig(config);
 
 const server = new McpServer({
   name: "orchard-mcp",
   version: packageJson.version,
 });
 
-registerCalendarTools(server);
-registerMailTools(server);
-registerReminderTools(server);
-registerSystemTools(server);
-registerFileTools(server);
-registerNumbersTools(server);
-registerPagesTools(server);
-registerKeynoteTools(server);
-registerNotesTools(server);
-registerContactsTools(server);
+registerEnabledTools(server, config);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/registerTools.ts
+++ b/src/registerTools.ts
@@ -1,0 +1,33 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { OrchardConfig, ModuleName } from "./config.js";
+import { registerCalendarTools } from "./tools/calendar.js";
+import { registerMailTools } from "./tools/mail.js";
+import { registerReminderTools } from "./tools/reminders.js";
+import { registerSystemTools } from "./tools/system.js";
+import { registerFileTools } from "./tools/files.js";
+import { registerNumbersTools } from "./tools/numbers.js";
+import { registerPagesTools } from "./tools/pages.js";
+import { registerKeynoteTools } from "./tools/keynote.js";
+import { registerNotesTools } from "./tools/notes.js";
+import { registerContactsTools } from "./tools/contacts.js";
+
+type ToolRegistrar = (server: McpServer, config: OrchardConfig) => void;
+
+const MODULE_REGISTRARS: Record<ModuleName, ToolRegistrar> = {
+  calendar: registerCalendarTools,
+  mail: registerMailTools,
+  reminders: registerReminderTools,
+  system: registerSystemTools,
+  files: registerFileTools,
+  numbers: registerNumbersTools,
+  pages: registerPagesTools,
+  keynote: registerKeynoteTools,
+  notes: registerNotesTools,
+  contacts: registerContactsTools,
+};
+
+export function registerEnabledTools(server: McpServer, config: OrchardConfig): void {
+  for (const name of config.enabledModules) {
+    MODULE_REGISTRARS[name](server, config);
+  }
+}

--- a/src/safety.ts
+++ b/src/safety.ts
@@ -34,6 +34,13 @@ export const OPERATION_PROFILES = {
     queueTimeoutMs: 1_000,
     maxOutputBytes: DEFAULT_OUTPUT_BYTES,
   },
+  calendarWrite: {
+    name: "calendar.write",
+    lane: "calendar",
+    timeoutMs: 20_000,
+    queueTimeoutMs: 1_000,
+    maxOutputBytes: DEFAULT_OUTPUT_BYTES,
+  },
   contactsRead: {
     name: "contacts.read",
     lane: "contacts",

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -321,6 +321,9 @@ async function printClientConfig(total: number): Promise<void> {
     log(`  Command: node`);
     log(`  Args: ${serverPath}`);
   }
+
+  log("Optional server config: ~/.config/orchard-mcp/config.json");
+  log("  Restrict modules or set calendar/reminder age limits (see README).");
 }
 
 // Step 6: Validation

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -1,11 +1,25 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import {
+  filterCalendarEvents,
+  isCalendarRangeFullyBeforeCutoff,
+} from "../ageFilters.js";
+import { OrchardConfig } from "../config.js";
 import { assertIsoDateRangeWithinDays } from "../resourceGuards.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
 const MAX_CALENDAR_RANGE_DAYS = 31;
 
-export function registerCalendarTools(server: McpServer): void {
+function formatEventsResponse(
+  data: unknown,
+  calendarMaxAgeDays: number | undefined
+): string {
+  const events = Array.isArray(data) ? data : [];
+  const filtered = filterCalendarEvents(events, calendarMaxAgeDays);
+  return JSON.stringify(filtered, null, 2);
+}
+
+export function registerCalendarTools(server: McpServer, config: OrchardConfig): void {
   server.tool(
     "calendar.list_calendars",
     "List all Apple Calendar calendars with account name, type, color, and read-only status.",
@@ -40,13 +54,23 @@ export function registerCalendarTools(server: McpServer): void {
         MAX_CALENDAR_RANGE_DAYS,
         "calendar.list_events"
       );
+      if (isCalendarRangeFullyBeforeCutoff(start, end, config.calendarMaxAgeDays)) {
+        return {
+          content: [{ type: "text", text: JSON.stringify([], null, 2) }],
+        };
+      }
       const args = ["events", "--start", start, "--end", end];
       if (calendarId) {
         args.push("--calendar", calendarId);
       }
       const data = await safeBridgeData(args, OPERATION_PROFILES.calendarRead);
       return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: formatEventsResponse(data, config.calendarMaxAgeDays),
+          },
+        ],
       };
     }
   );
@@ -76,7 +100,12 @@ export function registerCalendarTools(server: McpServer): void {
         OPERATION_PROFILES.calendarRead
       );
       return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: formatEventsResponse(data, config.calendarMaxAgeDays),
+          },
+        ],
       };
     }
   );
@@ -96,6 +125,11 @@ export function registerCalendarTools(server: McpServer): void {
         MAX_CALENDAR_RANGE_DAYS,
         "calendar.search"
       );
+      if (isCalendarRangeFullyBeforeCutoff(start, end, config.calendarMaxAgeDays)) {
+        return {
+          content: [{ type: "text", text: JSON.stringify([], null, 2) }],
+        };
+      }
       const data = await safeBridgeData([
         "search",
         query,
@@ -105,7 +139,12 @@ export function registerCalendarTools(server: McpServer): void {
         end,
       ], OPERATION_PROFILES.calendarRead);
       return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: formatEventsResponse(data, config.calendarMaxAgeDays),
+          },
+        ],
       };
     }
   );

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -148,4 +148,51 @@ export function registerCalendarTools(server: McpServer, config: OrchardConfig):
       };
     }
   );
+
+  server.tool(
+    "calendar.create_event",
+    "Create a new calendar event. Use calendar.list_calendars to find a writable calendar ID.",
+    {
+      title: z.string().describe("Event title"),
+      start: z
+        .string()
+        .describe("Start date in ISO 8601 format (e.g. 2026-02-17 or 2026-02-17T10:00:00Z)"),
+      end: z
+        .string()
+        .describe("End date in ISO 8601 format; must be on or after start"),
+      calendarId: z
+        .string()
+        .optional()
+        .describe("Optional calendar ID (from calendar.list_calendars); defaults to system default"),
+      isAllDay: z
+        .boolean()
+        .optional()
+        .describe("Create as an all-day event (default: false)"),
+      location: z.string().optional().describe("Event location"),
+      notes: z.string().optional().describe("Event notes"),
+      url: z.string().optional().describe("Event URL"),
+    },
+    async ({ title, start, end, calendarId, isAllDay, location, notes, url }) => {
+      const args = ["event-create", "--title", title, "--start", start, "--end", end];
+      if (calendarId) {
+        args.push("--calendar", calendarId);
+      }
+      if (isAllDay) {
+        args.push("--all-day");
+      }
+      if (location) {
+        args.push("--location", location);
+      }
+      if (notes) {
+        args.push("--notes", notes);
+      }
+      if (url) {
+        args.push("--url", url);
+      }
+      const data = await safeBridgeData(args, OPERATION_PROFILES.calendarWrite);
+      return {
+        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      };
+    }
+  );
 }

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerContactsTools(server: McpServer): void {
+export function registerContactsTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "contacts.list_groups",
     "List all contact groups with member counts. Requires Contacts access.",

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -1,9 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { assertBatchSize } from "../resourceGuards.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerFileTools(server: McpServer): void {
+export function registerFileTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "files.list",
     "List directory contents with metadata (name, size, dates, type). Paths relative to home directory.",

--- a/src/tools/keynote.ts
+++ b/src/tools/keynote.ts
@@ -1,9 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { requireKeynoteSlideForImageExport } from "../resourceGuards.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerKeynoteTools(server: McpServer): void {
+export function registerKeynoteTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "keynote.search",
     "Search for Keynote presentation files by name.",

--- a/src/tools/mail.ts
+++ b/src/tools/mail.ts
@@ -1,9 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { appendMailLocatorArgs, requireMailLocator } from "../mailSafety.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerMailTools(server: McpServer): void {
+export function registerMailTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "mail.list_accounts",
     "List all Apple Mail accounts with a bounded sample of mailbox names. Per-mailbox unread counts are intentionally omitted so account listing does not recursively scan Mail.app; use mail.unread_summary for unread counts. Requires Mail.app to be running.",

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -1,9 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { normalizeNotesSearchIn } from "../resourceGuards.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerNotesTools(server: McpServer): void {
+export function registerNotesTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "notes.list_folders",
     "List all Notes folders grouped by account with note counts. Requires Notes.app to be running and Automation permission.",

--- a/src/tools/numbers.ts
+++ b/src/tools/numbers.ts
@@ -1,9 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { requireNumbersRange } from "../resourceGuards.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerNumbersTools(server: McpServer): void {
+export function registerNumbersTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "numbers.search",
     "Search for Numbers spreadsheet files by name or content.",

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerPagesTools(server: McpServer): void {
+export function registerPagesTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "pages.search",
     "Search for Pages document files by name or content.",

--- a/src/tools/reminders.ts
+++ b/src/tools/reminders.ts
@@ -1,8 +1,19 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { filterReminders } from "../ageFilters.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerReminderTools(server: McpServer): void {
+function formatRemindersResponse(
+  data: unknown,
+  remindersMaxAgeDays: number | undefined
+): string {
+  const reminders = Array.isArray(data) ? data : [];
+  const filtered = filterReminders(reminders, remindersMaxAgeDays);
+  return JSON.stringify(filtered, null, 2);
+}
+
+export function registerReminderTools(server: McpServer, config: OrchardConfig): void {
   server.tool(
     "reminders.list_lists",
     "List all Apple Reminders lists with account name, color, and modification status.",
@@ -51,7 +62,12 @@ export function registerReminderTools(server: McpServer): void {
       }
       const data = await safeBridgeData(args, OPERATION_PROFILES.remindersRead);
       return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: formatRemindersResponse(data, config.remindersMaxAgeDays),
+          },
+        ],
       };
     }
   );
@@ -66,7 +82,12 @@ export function registerReminderTools(server: McpServer): void {
         OPERATION_PROFILES.remindersRead
       );
       return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: formatRemindersResponse(data, config.remindersMaxAgeDays),
+          },
+        ],
       };
     }
   );

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1,7 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { OrchardConfig } from "../config.js";
 import { OPERATION_PROFILES, safeBridgeData } from "../safety.js";
 
-export function registerSystemTools(server: McpServer): void {
+export function registerSystemTools(server: McpServer, _config: OrchardConfig): void {
   server.tool(
     "system.doctor",
     "Check orchard-mcp permissions status, list accessible Calendar accounts, Mail accounts, and Reminders status. Run this first to diagnose access issues.",

--- a/swift/Sources/AppleBridge/AppleBridge.swift
+++ b/swift/Sources/AppleBridge/AppleBridge.swift
@@ -38,6 +38,7 @@ struct AppleBridge: AsyncParsableCommand {
             Calendars.self,
             Events.self,
             Search.self,
+            EventCreate.self,
             MailAccounts.self,
             MailUnread.self,
             MailSearchCmd.self,
@@ -155,6 +156,50 @@ struct Search: AsyncParsableCommand {
 
     func run() async throws {
         await CalendarBridge.searchEvents(query: query, startISO: start, endISO: end)
+    }
+}
+
+struct EventCreate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "event-create",
+        abstract: "Create a new calendar event."
+    )
+
+    @Option(name: .long, help: "Event title")
+    var title: String
+
+    @Option(name: .long, help: "Start date (ISO 8601, e.g. 2026-02-17 or 2026-02-17T00:00:00Z)")
+    var start: String
+
+    @Option(name: .long, help: "End date (ISO 8601)")
+    var end: String
+
+    @Option(name: .long, help: "Calendar ID (from 'calendars' subcommand)")
+    var calendar: String?
+
+    @Flag(name: .long, help: "Create as an all-day event")
+    var allDay: Bool = false
+
+    @Option(name: .long, help: "Event location")
+    var location: String?
+
+    @Option(name: .long, help: "Event notes")
+    var notes: String?
+
+    @Option(name: .long, help: "Event URL")
+    var url: String?
+
+    func run() async throws {
+        await CalendarBridge.createEvent(
+            title: title,
+            startISO: start,
+            endISO: end,
+            calendarID: calendar,
+            isAllDay: allDay,
+            location: location,
+            notes: notes,
+            url: url
+        )
     }
 }
 

--- a/swift/Sources/AppleBridge/Calendar.swift
+++ b/swift/Sources/AppleBridge/Calendar.swift
@@ -181,7 +181,130 @@ enum CalendarBridge {
         JSONOutput.success(result)
     }
 
+    /// Create a new calendar event.
+    static func createEvent(
+        title: String,
+        startISO: String,
+        endISO: String,
+        calendarID: String?,
+        isAllDay: Bool,
+        location: String?,
+        notes: String?,
+        url: String?
+    ) async {
+        guard await requestAccess() else {
+            JSONOutput.error("Calendar access denied. Grant access in System Settings > Privacy & Security > Calendars.")
+            return
+        }
+
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            JSONOutput.error("Event title is required.")
+            return
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        guard var startDate = formatter.date(from: startISO) ?? parseFlexibleISO(startISO) else {
+            JSONOutput.error("Invalid start date: \(startISO). Use ISO 8601 format.")
+            return
+        }
+        guard var endDate = formatter.date(from: endISO) ?? parseFlexibleISO(endISO) else {
+            JSONOutput.error("Invalid end date: \(endISO). Use ISO 8601 format.")
+            return
+        }
+        guard endDate >= startDate else {
+            JSONOutput.error("event-create requires end date to be on or after start date.")
+            return
+        }
+
+        let calendar: EKCalendar
+        if let calID = calendarID {
+            guard let resolved = store.calendar(withIdentifier: calID) else {
+                JSONOutput.error("Calendar not found: \(calID)")
+                return
+            }
+            calendar = resolved
+        } else if let defaultCalendar = store.defaultCalendarForNewEvents {
+            calendar = defaultCalendar
+        } else {
+            JSONOutput.error("No default calendar available for new events.")
+            return
+        }
+
+        guard calendar.allowsContentModifications else {
+            JSONOutput.error("Calendar '\(calendar.title)' is read-only.")
+            return
+        }
+
+        if let urlStr = url, !urlStr.isEmpty {
+            guard URL(string: urlStr) != nil else {
+                JSONOutput.error("Invalid URL: \(urlStr)")
+                return
+            }
+        }
+
+        if isAllDay {
+            let cal = Calendar.current
+            startDate = cal.startOfDay(for: startDate)
+            let endStartOfDay = cal.startOfDay(for: endDate)
+            if endStartOfDay <= startDate {
+                endDate = cal.date(byAdding: .day, value: 1, to: startDate) ?? endDate
+            } else {
+                // Reason: EventKit uses an exclusive end date for all-day events.
+                endDate = cal.date(byAdding: .day, value: 1, to: endStartOfDay) ?? endDate
+            }
+        }
+
+        let event = EKEvent(eventStore: store)
+        event.title = trimmedTitle
+        event.startDate = startDate
+        event.endDate = endDate
+        event.isAllDay = isAllDay
+        event.calendar = calendar
+
+        if let location = location, !location.isEmpty {
+            event.location = location
+        }
+        if let notes = notes, !notes.isEmpty {
+            event.notes = notes
+        }
+        if let urlStr = url, !urlStr.isEmpty, let parsedURL = URL(string: urlStr) {
+            event.url = parsedURL
+        }
+
+        do {
+            try store.save(event, span: .thisEvent, commit: true)
+            JSONOutput.success(formatEvent(event))
+        } catch {
+            JSONOutput.error("Failed to create event: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: - Helpers
+
+    private static func formatEvent(_ evt: EKEvent) -> [String: Any] {
+        var dict: [String: Any] = [
+            "id": evt.eventIdentifier ?? "",
+            "title": evt.title ?? "(no title)",
+            "start": iso8601(evt.startDate),
+            "end": iso8601(evt.endDate),
+            "isAllDay": evt.isAllDay,
+            "calendar": evt.calendar.title,
+            "calendarId": evt.calendar.calendarIdentifier
+        ]
+        if let location = evt.location, !location.isEmpty {
+            dict["location"] = location
+        }
+        if let notes = evt.notes, !notes.isEmpty {
+            dict["notes"] = notes
+        }
+        if let url = evt.url {
+            dict["url"] = url.absoluteString
+        }
+        return dict
+    }
 
     private static func parseFlexibleISO(_ str: String) -> Date? {
         // Reason: Accept date-only strings like "2026-02-17" without time component.

--- a/swift/Sources/AppleBridge/Calendar.swift
+++ b/swift/Sources/AppleBridge/Calendar.swift
@@ -203,14 +203,11 @@ enum CalendarBridge {
             return
         }
 
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-        guard var startDate = formatter.date(from: startISO) ?? parseFlexibleISO(startISO) else {
+        guard var startDate = parseDateISO(startISO) else {
             JSONOutput.error("Invalid start date: \(startISO). Use ISO 8601 format.")
             return
         }
-        guard var endDate = formatter.date(from: endISO) ?? parseFlexibleISO(endISO) else {
+        guard var endDate = parseDateISO(endISO) else {
             JSONOutput.error("Invalid end date: \(endISO). Use ISO 8601 format.")
             return
         }
@@ -304,6 +301,20 @@ enum CalendarBridge {
             dict["url"] = url.absoluteString
         }
         return dict
+    }
+
+    /// Parse an ISO 8601 date/datetime string in the broadest sensible set of formats.
+    /// Tries: fractional-seconds datetime → plain datetime → date-only.
+    private static func parseDateISO(_ str: String) -> Date? {
+        let withFrac = ISO8601DateFormatter()
+        withFrac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = withFrac.date(from: str) { return d }
+
+        let noFrac = ISO8601DateFormatter()
+        noFrac.formatOptions = [.withInternetDateTime]
+        if let d = noFrac.date(from: str) { return d }
+
+        return parseFlexibleISO(str)
     }
 
     private static func parseFlexibleISO(_ str: String) -> Date? {

--- a/tests/age-filters.test.ts
+++ b/tests/age-filters.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  cutoffDate,
+  filterCalendarEvents,
+  filterReminders,
+  isCalendarRangeFullyBeforeCutoff,
+} from "../src/ageFilters.js";
+
+const NOW = new Date("2026-06-18T15:00:00");
+
+describe("age filters", () => {
+  it("computes cutoff as start of today minus maxAgeDays", () => {
+    const cutoff = cutoffDate(30, NOW);
+    const expected = new Date(NOW.getFullYear(), NOW.getMonth(), NOW.getDate());
+    expected.setDate(expected.getDate() - 30);
+    assert.equal(cutoff.getTime(), expected.getTime());
+  });
+
+  it("returns false when maxAgeDays is undefined", () => {
+    assert.equal(
+      isCalendarRangeFullyBeforeCutoff("2020-01-01", "2020-01-02", undefined, NOW),
+      false
+    );
+  });
+
+  it("detects calendar ranges fully before the cutoff", () => {
+    assert.equal(
+      isCalendarRangeFullyBeforeCutoff("2020-01-01", "2020-01-02", 30, NOW),
+      true
+    );
+    assert.equal(
+      isCalendarRangeFullyBeforeCutoff("2026-06-01", "2026-06-18", 30, NOW),
+      false
+    );
+  });
+
+  it("filters calendar events by end date", () => {
+    const events = [
+      { id: "old", end: "2020-01-01T10:00:00Z" },
+      { id: "recent", end: "2026-06-18T10:00:00Z" },
+      { id: "future", end: "2026-07-01T10:00:00Z" },
+    ];
+
+    const filtered = filterCalendarEvents(events, 30, NOW);
+    assert.deepEqual(
+      filtered.map((event) => event.id),
+      ["recent", "future"]
+    );
+  });
+
+  it("keeps calendar events when maxAgeDays is undefined", () => {
+    const events = [{ id: "old", end: "2020-01-01T10:00:00Z" }];
+    assert.deepEqual(filterCalendarEvents(events, undefined, NOW), events);
+  });
+
+  it("filters old completed reminders but keeps incomplete overdue items", () => {
+    const reminders = [
+      {
+        id: "old-completed",
+        isCompleted: true,
+        completionDate: "2020-01-01T10:00:00Z",
+      },
+      {
+        id: "recent-completed",
+        isCompleted: true,
+        completionDate: "2026-06-10T10:00:00Z",
+      },
+      {
+        id: "overdue-incomplete",
+        isCompleted: false,
+        dueDate: "2020-01-01T10:00:00Z",
+      },
+      {
+        id: "undated-incomplete",
+        isCompleted: false,
+      },
+      {
+        id: "completed-no-date",
+        isCompleted: true,
+      },
+    ];
+
+    const filtered = filterReminders(reminders, 30, NOW);
+    assert.deepEqual(
+      filtered.map((reminder) => reminder.id),
+      [
+        "recent-completed",
+        "overdue-incomplete",
+        "undated-incomplete",
+        "completed-no-date",
+      ]
+    );
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -127,4 +127,16 @@ describe("config loading", () => {
 
     assert.throws(() => loadConfig(), /Failed to read config file/);
   });
+
+  it("rejects config file that contains null instead of an object", () => {
+    writeFileSync(process.env.ORCHARD_MCP_CONFIG!, "null");
+
+    assert.throws(() => loadConfig(), /Failed to read config file.*null/);
+  });
+
+  it("rejects config file that contains a JSON array instead of an object", () => {
+    writeFileSync(process.env.ORCHARD_MCP_CONFIG!, '["calendar"]');
+
+    assert.throws(() => loadConfig(), /Failed to read config file.*array/);
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig, ALL_MODULES } from "../src/config.js";
+
+const ENV_KEYS = [
+  "ORCHARD_MCP_CONFIG",
+  "ORCHARD_MCP_MODULES",
+  "ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS",
+  "ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS",
+] as const;
+
+describe("config loading", () => {
+  let savedEnv: Record<string, string | undefined>;
+  let tempDir: string;
+
+  beforeEach(() => {
+    savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+    tempDir = mkdtempSync(join(tmpdir(), "orchard-mcp-config-"));
+    process.env.ORCHARD_MCP_CONFIG = join(tempDir, "config.json");
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("defaults to all modules with no age limits when config file is missing", () => {
+    const config = loadConfig();
+    assert.deepEqual(config.enabledModules, ALL_MODULES);
+    assert.equal(config.calendarMaxAgeDays, undefined);
+    assert.equal(config.remindersMaxAgeDays, undefined);
+  });
+
+  it("loads modules and age limits from config file", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({
+        modules: ["calendar", "mail", "system"],
+        calendarMaxAgeDays: 365,
+        remindersMaxAgeDays: 90,
+      })
+    );
+
+    const config = loadConfig();
+    assert.deepEqual(config.enabledModules, ["calendar", "mail", "system"]);
+    assert.equal(config.calendarMaxAgeDays, 365);
+    assert.equal(config.remindersMaxAgeDays, 90);
+  });
+
+  it("defaults modules to all when config file omits modules key", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({ calendarMaxAgeDays: 30 })
+    );
+
+    const config = loadConfig();
+    assert.deepEqual(config.enabledModules, ALL_MODULES);
+    assert.equal(config.calendarMaxAgeDays, 30);
+  });
+
+  it("lets environment variables override config file values", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({
+        modules: ["calendar"],
+        calendarMaxAgeDays: 10,
+        remindersMaxAgeDays: 20,
+      })
+    );
+    process.env.ORCHARD_MCP_MODULES = "mail, files";
+    process.env.ORCHARD_MCP_CALENDAR_MAX_AGE_DAYS = "100";
+    process.env.ORCHARD_MCP_REMINDERS_MAX_AGE_DAYS = "200";
+
+    const config = loadConfig();
+    assert.deepEqual(config.enabledModules, ["mail", "files"]);
+    assert.equal(config.calendarMaxAgeDays, 100);
+    assert.equal(config.remindersMaxAgeDays, 200);
+  });
+
+  it("rejects unknown module names", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({ modules: ["calendar", "not-a-module"] })
+    );
+
+    assert.throws(() => loadConfig(), /unknown module "not-a-module"/);
+  });
+
+  it("rejects empty modules array in config file", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({ modules: [] })
+    );
+
+    assert.throws(() => loadConfig(), /must include at least one module/);
+  });
+
+  it("rejects empty ORCHARD_MCP_MODULES env var", () => {
+    process.env.ORCHARD_MCP_MODULES = "";
+
+    assert.throws(() => loadConfig(), /ORCHARD_MCP_MODULES.*must include at least one module/);
+  });
+
+  it("rejects invalid age values", () => {
+    writeFileSync(
+      process.env.ORCHARD_MCP_CONFIG!,
+      JSON.stringify({ calendarMaxAgeDays: -1 })
+    );
+
+    assert.throws(() => loadConfig(), /calendarMaxAgeDays.*non-negative integer/);
+  });
+
+  it("rejects malformed config JSON", () => {
+    writeFileSync(process.env.ORCHARD_MCP_CONFIG!, "{not json");
+
+    assert.throws(() => loadConfig(), /Failed to read config file/);
+  });
+});

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -2,16 +2,8 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { registerCalendarTools } from "../src/tools/calendar.js";
-import { registerContactsTools } from "../src/tools/contacts.js";
-import { registerFileTools } from "../src/tools/files.js";
-import { registerKeynoteTools } from "../src/tools/keynote.js";
-import { registerMailTools } from "../src/tools/mail.js";
-import { registerNotesTools } from "../src/tools/notes.js";
-import { registerNumbersTools } from "../src/tools/numbers.js";
-import { registerPagesTools } from "../src/tools/pages.js";
-import { registerReminderTools } from "../src/tools/reminders.js";
-import { registerSystemTools } from "../src/tools/system.js";
+import { ALL_MODULES } from "../src/config.js";
+import { registerEnabledTools } from "../src/registerTools.js";
 
 const repoRoot = new URL("../", import.meta.url);
 
@@ -27,16 +19,7 @@ const packageJson = JSON.parse(readRepoFile("package.json")) as {
 
 function registeredToolCount(): number {
   const server = new McpServer({ name: "orchard-mcp", version: packageJson.version });
-  registerCalendarTools(server);
-  registerMailTools(server);
-  registerReminderTools(server);
-  registerSystemTools(server);
-  registerFileTools(server);
-  registerNumbersTools(server);
-  registerPagesTools(server);
-  registerKeynoteTools(server);
-  registerNotesTools(server);
-  registerContactsTools(server);
+  registerEnabledTools(server, { enabledModules: ALL_MODULES });
   return Object.keys((server as any)._registeredTools as Record<string, unknown>).length;
 }
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -2,20 +2,16 @@ import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { registerCalendarTools } from "../src/tools/calendar.js";
-import { registerMailTools } from "../src/tools/mail.js";
-import { registerReminderTools } from "../src/tools/reminders.js";
-import { registerSystemTools } from "../src/tools/system.js";
-import { registerFileTools } from "../src/tools/files.js";
-import { registerNumbersTools } from "../src/tools/numbers.js";
-import { registerPagesTools } from "../src/tools/pages.js";
-import { registerKeynoteTools } from "../src/tools/keynote.js";
-import { registerNotesTools } from "../src/tools/notes.js";
-import { registerContactsTools } from "../src/tools/contacts.js";
+import { ALL_MODULES, OrchardConfig } from "../src/config.js";
+import { registerEnabledTools } from "../src/registerTools.js";
 
 const packageJson = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8")
 ) as { version: string };
+
+const DEFAULT_CONFIG: OrchardConfig = {
+  enabledModules: ALL_MODULES,
+};
 
 const EXPECTED_TOOLS = [
   // Calendar (4)
@@ -95,26 +91,21 @@ const EXPECTED_TOOLS = [
   "contacts.read_contact",
 ];
 
+function registeredToolNames(server: McpServer): string[] {
+  const tools = (server as any)._registeredTools as Record<string, unknown>;
+  return Object.keys(tools);
+}
+
 describe("tool registration", () => {
   let server: McpServer;
 
   before(() => {
     server = new McpServer({ name: "orchard-mcp", version: packageJson.version });
-    registerCalendarTools(server);
-    registerMailTools(server);
-    registerReminderTools(server);
-    registerSystemTools(server);
-    registerFileTools(server);
-    registerNumbersTools(server);
-    registerPagesTools(server);
-    registerKeynoteTools(server);
-    registerNotesTools(server);
-    registerContactsTools(server);
+    registerEnabledTools(server, DEFAULT_CONFIG);
   });
 
   it("registers exactly 65 tools", () => {
-    const tools = (server as any)._registeredTools as Record<string, unknown>;
-    const names = Object.keys(tools);
+    const names = registeredToolNames(server);
     assert.equal(names.length, 65, `Expected 65 tools, got ${names.length}: ${names.join(", ")}`);
   });
 
@@ -124,4 +115,19 @@ describe("tool registration", () => {
       assert.ok(name in tools, `Tool "${name}" not registered`);
     });
   }
+
+  it("registers only enabled modules", () => {
+    const restrictedServer = new McpServer({
+      name: "orchard-mcp",
+      version: packageJson.version,
+    });
+    registerEnabledTools(restrictedServer, {
+      enabledModules: ["calendar", "system"],
+    });
+
+    const names = registeredToolNames(restrictedServer);
+    assert.equal(names.length, 5);
+    assert.ok(names.every((name) => name.startsWith("calendar.") || name.startsWith("system.")));
+    assert.ok(!names.some((name) => name.startsWith("mail.")));
+  });
 });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -14,11 +14,12 @@ const DEFAULT_CONFIG: OrchardConfig = {
 };
 
 const EXPECTED_TOOLS = [
-  // Calendar (4)
+  // Calendar (5)
   "calendar.list_calendars",
   "calendar.list_events",
   "calendar.today",
   "calendar.search",
+  "calendar.create_event",
   // Mail (7)
   "mail.list_accounts",
   "mail.unread_summary",
@@ -104,9 +105,9 @@ describe("tool registration", () => {
     registerEnabledTools(server, DEFAULT_CONFIG);
   });
 
-  it("registers exactly 65 tools", () => {
+  it("registers exactly 66 tools", () => {
     const names = registeredToolNames(server);
-    assert.equal(names.length, 65, `Expected 65 tools, got ${names.length}: ${names.join(", ")}`);
+    assert.equal(names.length, 66, `Expected 66 tools, got ${names.length}: ${names.join(", ")}`);
   });
 
   for (const name of EXPECTED_TOOLS) {
@@ -126,7 +127,7 @@ describe("tool registration", () => {
     });
 
     const names = registeredToolNames(restrictedServer);
-    assert.equal(names.length, 5);
+    assert.equal(names.length, 6);
     assert.ok(names.every((name) => name.startsWith("calendar.") || name.startsWith("system.")));
     assert.ok(!names.some((name) => name.startsWith("mail.")));
   });


### PR DESCRIPTION
## Summary
- Add `calendar.create_event` MCP tool for creating calendar events via native EventKit (`EKEvent` + `store.save(_:span:commit:)`)
- Add Swift `event-create` CLI subcommand with support for title, start/end dates, optional calendar ID, all-day events, location, notes, and URL
- Add `calendarWrite` safety profile on the Calendar lane with modifiability validation before save
- Bump tool count from 65 to 66 across tests and docs

## Test plan
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [ ] Manual: `apple-bridge event-create --title "Test" --start "2026-06-18T10:00:00" --end "2026-06-18T11:00:00"` and verify via `calendar.today`